### PR TITLE
Vertical centering and responsive layout

### DIFF
--- a/src/login/Template.tsx
+++ b/src/login/Template.tsx
@@ -22,7 +22,7 @@ const Container = styled.div(({ theme }) => ({
 }))
 
 const Card = styled.div({
-  width: "600px",
+  width: "100%",
   maxWidth: "600px",
   display: "flex",
   flexDirection: "column",
@@ -54,7 +54,8 @@ const Footer = styled.footer(({ theme }) => ({
   color: theme.custom.colors.silverGrayDark,
   display: "flex",
   flexDirection: "column",
-  gap: "10px"
+  gap: "10px",
+  paddingInline: "32px"
 }))
 
 export default function Template(props: TemplateProps<KcContext, I18n>) {


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->

- https://github.com/mitodl/hq/issues/7524

### Description (What does it do?)
<!--- Describe your changes in detail -->

- Vertically centers the page content until it overflows the screen height.
- At mobile breakpoint, fixes the top spacing.

### Screenshots (if appropriate):
<!--- optional - delete if empty --->


| Before    | After |
| -------- | ------- |
| <img width="1086" height="775" alt="image" src="https://github.com/user-attachments/assets/efb11d6f-cd88-4094-93f4-c864916b1565" />  | <img width="1084" height="773" alt="image" src="https://github.com/user-attachments/assets/c5561720-d4d8-4cf9-803a-b5234ad79c73" />   |
| <img width="577" height="775" alt="image" src="https://github.com/user-attachments/assets/8d1596e6-6ce0-4288-990c-c79711bbfd09" /> | <img width="579" height="764" alt="image" src="https://github.com/user-attachments/assets/1ce6514c-0353-4446-a5e9-2e8961072b15" />  |



### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

Test in _actual_ Keycloak and not Storybook to correctly replicate.

- Run `yarn start`
- Navigate to https://my-theme.keycloakify.dev/, which will redirect to your local instance.
- Ensure the page contents are vertically centered, or pinned at mobile breakpoint (600px). 
- Hit "Sign up" and check that the taller registration form layout is also correct
