### PR TITLE
Update email template

### DIFF
--- a/src/login/KcPage.tsx
+++ b/src/login/KcPage.tsx
@@ -15,6 +15,7 @@ import LoginPassword from "./pages/LoginPassword"
 import LoginUpdatePassword from "./pages/LoginUpdatePassword"
 import LoginVerifyEmail from "./pages/LoginVerifyEmail"
 import LoginPageExpired from "./pages/LoginPageExpired"
+import UpdateEmail from "./pages/UpdateEmail"
 
 const doMakeUserConfirmPassword = true
 
@@ -95,7 +96,16 @@ export default function KcPage(props: { kcContext: KcContext }) {
                   doUseDefaultCss={false}
                 />
               )
-
+            case "update-email.ftl":
+              return (
+                <UpdateEmail
+                  {...{ kcContext, i18n, classes }}
+                  Template={Template}
+                  doUseDefaultCss={false}
+                  UserProfileFormFields={UserProfileFormFields}
+                  doMakeUserConfirmPassword={doMakeUserConfirmPassword}
+                />
+              )
             default:
               return (
                 <DefaultPage

--- a/src/login/Template.tsx
+++ b/src/login/Template.tsx
@@ -62,7 +62,6 @@ export default function Template(props: TemplateProps<KcContext, I18n>) {
   const {
     displayInfo = false,
     displayMessage = true,
-    displayRequiredFields = false,
     headerNode,
     socialProvidersNode = null,
     infoNode = null,
@@ -74,8 +73,6 @@ export default function Template(props: TemplateProps<KcContext, I18n>) {
   } = props
 
   const { msg, msgStr } = i18n
-
-  console.log("kcContext", kcContext)
 
   const { realm, auth, url, message, isAppInitiatedAction, olSettings } = kcContext
 
@@ -106,20 +103,6 @@ export default function Template(props: TemplateProps<KcContext, I18n>) {
                 {headerNode}
               </Title>
             )
-
-            if (displayRequiredFields) {
-              return (
-                <div>
-                  <div className="subtitle">
-                    <span className="subtitle">
-                      <span className="required">*</span>
-                      {msg("requiredFields")}
-                    </span>
-                  </div>
-                  <div className="col-md-10">{node}</div>
-                </div>
-              )
-            }
 
             return node
           })()}

--- a/src/login/i18n.ts
+++ b/src/login/i18n.ts
@@ -88,7 +88,9 @@ const { useI18n, ofTypeI18n } = i18nBuilder
       "password-help-text": "Sign in by entering your password.",
       "auth-username-form-help-text": "Start sign in by entering your username",
       "auth-username-password-form-help-text":
-        "Sign in by entering your username and password."
+        "Sign in by entering your username and password.",
+      updateEmailTitle: "Update your email",
+      "error-user-attribute-required": "Please fill in this field."
     }
   })
   .build()

--- a/src/login/pages/UpdateEmail.stories.tsx
+++ b/src/login/pages/UpdateEmail.stories.tsx
@@ -1,0 +1,39 @@
+import type { Meta, StoryObj } from "@storybook/react-vite"
+import { createKcPageStory } from "../KcPageStory"
+
+const { KcPageStory } = createKcPageStory({ pageId: "update-email.ftl" })
+
+const meta = {
+  title: "login/update-email.ftl",
+  component: KcPageStory
+} satisfies Meta<typeof KcPageStory>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  render: () => <KcPageStory />
+}
+
+/**
+ * WithAppInitiatedAction:
+ * - Purpose: Tests when the form is displayed as part of an application-initiated action.
+ * - Scenario: The component renders the form with additional buttons like "Cancel."
+ * - Key Aspect: Ensures the "Cancel" button is visible and functional during app-initiated actions.
+ */
+export const WithAppInitiatedAction: Story = {
+  render: () => (
+    <KcPageStory
+      kcContext={{
+        url: {
+          loginAction: "/mock-login-action"
+        },
+        messagesPerField: {
+          exists: () => false
+        },
+        isAppInitiatedAction: true
+      }}
+    />
+  )
+}

--- a/src/login/pages/UpdateEmail.tsx
+++ b/src/login/pages/UpdateEmail.tsx
@@ -1,0 +1,75 @@
+import styled from "@emotion/styled"
+import type { JSX } from "keycloakify/tools/JSX"
+import { useState } from "react"
+import type { LazyOrNot } from "keycloakify/tools/LazyOrNot"
+import { getKcClsx } from "keycloakify/login/lib/kcClsx"
+import type { UserProfileFormFieldsProps } from "keycloakify/login/UserProfileFormFieldsProps"
+import type { PageProps } from "keycloakify/login/pages/PageProps"
+import type { KcContext } from "../KcContext"
+import type { I18n } from "../i18n"
+import { Form, Button } from "../components/Elements"
+
+const Buttons = styled.div(({ theme }) => ({
+  display: "flex",
+  gap: theme.spacing(2),
+  justifyContent: "flex-end"
+}))
+
+type UpdateEmailProps = PageProps<Extract<KcContext, { pageId: "update-email.ftl" }>, I18n> & {
+  UserProfileFormFields: LazyOrNot<(props: UserProfileFormFieldsProps) => JSX.Element>
+  doMakeUserConfirmPassword: boolean
+}
+
+export default function UpdateEmail(props: UpdateEmailProps) {
+  const { kcContext, i18n, doUseDefaultCss, Template, classes, UserProfileFormFields, doMakeUserConfirmPassword } = props
+
+  const { kcClsx } = getKcClsx({
+    doUseDefaultCss,
+    classes
+  })
+
+  const { msg, msgStr } = i18n
+
+  const [isFormSubmittable, setIsFormSubmittable] = useState(false)
+
+  const { url, messagesPerField, isAppInitiatedAction } = kcContext
+
+  return (
+    <Template
+      kcContext={kcContext}
+      i18n={i18n}
+      doUseDefaultCss={doUseDefaultCss}
+      classes={classes}
+      displayMessage={messagesPerField.exists("global")}
+      displayRequiredFields
+      headerNode={msg("updateEmailTitle")}
+    >
+      <Form id="kc-update-email-Form" action={url.loginAction} method="post">
+        <UserProfileFormFields
+          kcContext={kcContext}
+          i18n={i18n}
+          kcClsx={kcClsx}
+          onIsFormSubmittableValueChange={setIsFormSubmittable}
+          doMakeUserConfirmPassword={doMakeUserConfirmPassword}
+        />
+
+        <div>
+          <div id="kc-form-options">
+            <div />
+          </div>
+
+          <Buttons id="kc-form-buttons">
+            {isAppInitiatedAction && (
+              <Button type="submit" name="cancel-aia" value="true">
+                {msg("doCancel")}
+              </Button>
+            )}
+            <Button disabled={!isFormSubmittable} type="submit">
+              {msgStr("doSubmit")}
+            </Button>
+          </Buttons>
+        </div>
+      </Form>
+    </Template>
+  )
+}


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->

- Closes https://github.com/mitodl/hq/issues/8065

### Description (What does it do?)
<!--- Describe your changes in detail -->

Provides a template for the update email screen, applying the Smoot design system.

### Screenshots (if appropriate):

<img width="778" height="664" alt="image" src="https://github.com/user-attachments/assets/b9773994-9499-421c-9d98-649aafe9a6ce" />



### How can this be tested?

- Run `yarn storybook`.

- Confirm the template renders as expected at:
  - http://localhost:6007/?path=/story/login-update-email-ftl--default
  - http://localhost:6007/?path=/story/login-update-email-ftl--with-app-initiated-action
 
