### PR TITLE
remove sign up message

### DIFF
--- a/src/login/i18n.ts
+++ b/src/login/i18n.ts
@@ -8,7 +8,7 @@ const { useI18n, ofTypeI18n } = i18nBuilder
   .withCustomTranslations({
     en: {
       doLogIn: "Next",
-      loginAccountTitle: "Log in",
+      loginAccountTitle: "Enter your email to start.",
       loginGreeting: "Hello, {0}",
       noAccount: "Don't have an account? ",
       doRegister: "Sign Up",

--- a/src/login/pages/Login.tsx
+++ b/src/login/pages/Login.tsx
@@ -2,7 +2,7 @@ import { useState } from "react"
 import type { PageProps } from "keycloakify/login/pages/PageProps"
 import type { KcContext } from "../KcContext"
 import type { I18n } from "../i18n"
-import { Link, Button, Form, Info, ButtonLink, SocialProviderButtonLink, OrBar, RevealPasswordButton } from "../components/Elements"
+import { Link, Button, Form, ButtonLink, SocialProviderButtonLink, OrBar, RevealPasswordButton } from "../components/Elements"
 import mitLogo from "../components/mit-logo.svg"
 import { TextField } from "@mitodl/smoot-design"
 
@@ -24,18 +24,6 @@ export default function Login(props: PageProps<Extract<KcContext, { pageId: "log
       displayMessage={!messagesPerField.existsError("username", "password")}
       headerNode={loginAttempt?.userFullname ? msg("loginGreeting", loginAttempt.userFullname) : msg("loginAccountTitle")}
       displayInfo={realm.password && realm.registrationAllowed && !registrationDisabled}
-      infoNode={
-        <div id="kc-registration-container">
-          <div id="kc-registration">
-            <Info>
-              {msg("noAccount")}
-              <Link tabIndex={0} href={url.registrationUrl}>
-                {msg("doRegister")}
-              </Link>
-            </Info>
-          </div>
-        </div>
-      }
       socialProvidersNode={
         <>
           {realm.password && social?.providers !== undefined && social.providers.length !== 0 && (

--- a/src/login/pages/LoginUsername.tsx
+++ b/src/login/pages/LoginUsername.tsx
@@ -3,7 +3,7 @@ import { clsx } from "keycloakify/tools/clsx"
 import type { PageProps } from "keycloakify/login/pages/PageProps"
 import type { KcContext } from "../KcContext"
 import type { I18n } from "../i18n"
-import { Link, Button, Form, Info, SocialProviderButtonLink, OrBar } from "../components/Elements"
+import { Button, Form, SocialProviderButtonLink, OrBar } from "../components/Elements"
 import mitLogo from "../components/mit-logo.svg"
 import { TextField } from "@mitodl/smoot-design"
 
@@ -25,16 +25,6 @@ export default function LoginUsername(props: PageProps<Extract<KcContext, { page
       displayMessage={!messagesPerField.existsError("username")}
       displayInfo={realm.password && realm.registrationAllowed && !registrationDisabled}
       headerNode={loginAttempt?.userFullname ? msg("loginGreeting", loginAttempt.userFullname) : msg("loginAccountTitle")}
-      infoNode={
-        <div id="kc-registration">
-          <Info>
-            {msg("noAccount")}
-            <Link tabIndex={6} href={url.registrationUrl}>
-              {msg("doRegister")}
-            </Link>
-          </Info>
-        </div>
-      }
       socialProvidersNode={
         <>
           {realm.password && social?.providers !== undefined && social.providers.length !== 0 && (


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/8333

### Description (What does it do?)
This PR removes the `infoNode` entries on the login page that displays the "Don't have an account? Sign Up" message.

### Screenshots (if appropriate):
<img width="2560" height="1271" alt="image" src="https://github.com/user-attachments/assets/6b56f845-8819-404f-8811-1d37ea93e43e" />

### How can this be tested?
- Make sure you have the app fully installed by reading the Readme and following the instructions, but it boils down to having Node, Yarn and Maven installed locally and then running:
```
yarn install
yarn build-keycloak-theme
yarn run storybook
```
- Visit http://localhost:6006
- View the stories related to the login window and verify that the sign up text / link has been removed
