### PR TITLE
Remove the title message as fallback when no full name

### DIFF
--- a/src/login/i18n.ts
+++ b/src/login/i18n.ts
@@ -9,7 +9,7 @@ const { useI18n, ofTypeI18n } = i18nBuilder
     en: {
       doLogIn: "Next",
       loginAccountTitle: "Enter your email to start.",
-      loginGreeting: "Hello, {0}",
+      loginGreeting: "Hello, {0}!",
       noAccount: "Don't have an account? ",
       doRegister: "Sign Up",
       doForgotPassword: "Reset password?",

--- a/src/login/pages/LoginPassword.stories.tsx
+++ b/src/login/pages/LoginPassword.stories.tsx
@@ -16,6 +16,25 @@ export const Default: Story = {
   render: () => <KcPageStory />
 }
 
+export const WithUserFullname: Story = {
+  render: () => (
+    <KcPageStory
+      kcContext={{
+        realm: {
+          resetPasswordAllowed: true
+        },
+        url: {
+          loginAction: "/mock-login",
+          loginResetCredentialsUrl: "/mock-reset-password"
+        },
+        loginAttempt: {
+          userFullname: "First Last"
+        }
+      }}
+    />
+  )
+}
+
 /**
  * WithPasswordError:
  * - Purpose: Tests the behavior when an error occurs in the password field (e.g., incorrect password).

--- a/src/login/pages/LoginPassword.tsx
+++ b/src/login/pages/LoginPassword.tsx
@@ -19,7 +19,7 @@ export default function LoginPassword(props: PageProps<Extract<KcContext, { page
       i18n={i18n}
       doUseDefaultCss={doUseDefaultCss}
       classes={classes}
-      headerNode={loginAttempt?.userFullname ? msg("loginGreeting", loginAttempt.userFullname) : msg("loginAccountTitle")}
+      headerNode={loginAttempt?.userFullname ? msg("loginGreeting", loginAttempt.userFullname) : ""}
       displayMessage={!messagesPerField.existsError("password")}
     >
       <div id="kc-form">


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->

- https://github.com/mitodl/hq/issues/8487

### Description (What does it do?)
<!--- Describe your changes in detail -->

Removes the `loginAccountTitle` as a fallback when we don't have a full name for the user.


### Screenshots (if appropriate):


<img width="825" height="626" alt="image" src="https://github.com/user-attachments/assets/b831dfc5-4a44-4e77-a3c6-6611401e9929" />

If the full name is available we display the greeting (with ! reinstated):

<img width="786" height="799" alt="image" src="https://github.com/user-attachments/assets/4ca54935-be52-4e16-ab50-3fb834855e06" />



### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

- Run `yarn start`
- Create a user at http://localhost:8080/admin/master/console/#/myrealm/users
- Navigate to the login screen at http://localhost:8080/realms/myrealm/account/
- Enter the email address and confirm that no title is displayed on the password screen.

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->

We recently set the title to "Enter your email to start." (previously just "Log In"). We do expect that there will always be a full name on non-SSO accounts as it is required in the registration form, however in any case do not want to prompt to enter an email on the password screen.

<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
