### PR TITLE
Populate the registration form with email

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ol-keycloakify",
-  "version": "0.0.20",
+  "version": "0.0.21",
   "description": "Keycloakify theme for Open Learning",
   "repository": {
     "type": "git",

--- a/src/login/UserProfileFormFields.tsx
+++ b/src/login/UserProfileFormFields.tsx
@@ -231,6 +231,12 @@ function InputTag(props: InputFieldByTypeProps & { fieldIndex: number | undefine
 
   const { advancedMsgStr } = i18n
 
+  let initialValue = ""
+
+  if (attribute.name === "email") {
+    initialValue = sessionStorage.getItem("email") || ""
+  }
+
   return (
     <>
       <StyledTextField
@@ -260,7 +266,7 @@ function InputTag(props: InputFieldByTypeProps & { fieldIndex: number | undefine
 
           assert(typeof valueOrValues === "string")
 
-          return valueOrValues
+          return valueOrValues || initialValue
         })()}
         placeholder={
           attribute.annotations.inputTypePlaceholder === undefined ? undefined : advancedMsgStr(attribute.annotations.inputTypePlaceholder)

--- a/src/login/pages/LoginUsername.tsx
+++ b/src/login/pages/LoginUsername.tsx
@@ -7,6 +7,8 @@ import { Button, Form, SocialProviderButtonLink, OrBar, StyledTextField } from "
 import mitLogo from "../components/mit-logo.svg"
 
 export default function LoginUsername(props: PageProps<Extract<KcContext, { pageId: "login-username.ftl" }>, I18n>) {
+  const [username, setUsername] = useState("")
+
   const { kcContext, i18n, doUseDefaultCss, Template, classes } = props
 
   const { social, realm, url, usernameHidden, login, registrationDisabled, messagesPerField, loginAttempt } = kcContext
@@ -47,6 +49,9 @@ export default function LoginUsername(props: PageProps<Extract<KcContext, { page
             <Form
               id="kc-form-login"
               onSubmit={() => {
+                if (realm.registrationEmailAsUsername && username) {
+                  sessionStorage.setItem("email", username.trim())
+                }
                 setIsLoginButtonDisabled(true)
                 return true
               }}
@@ -68,6 +73,9 @@ export default function LoginUsername(props: PageProps<Extract<KcContext, { page
                   }}
                   errorText={messagesPerField.getFirstError("username")}
                   error={messagesPerField.existsError("username")}
+                  onChange={e => {
+                    setUsername(e.target.value)
+                  }}
                 />
               )}
               <div id="kc-form-buttons">


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->

- https://github.com/mitodl/hq/issues/8554

### Description (What does it do?)
<!--- Describe your changes in detail -->

- Sets the email address on session storage when the login form is submitted.
- Populates the registration form email field with the value.

### Screenshots (if appropriate):


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

- Run `yarn start`
- Navigate to https://my-theme.keycloakify.dev/
- Enter an email address not registered
- This should take you to the registration page, depending on your realm config. If not, you can log the `kcContext.url.registrationUrl` on the login page. If that page doesn't load, ensure that "User registration" is turned on in "Realm Settings" -> "Login"
- Note that you'll need to load the URL in the same tab as we're using session storage.
- Verify that your email address is pre-filled.
