### PR TITLE
8550/jk global password message

### DIFF
--- a/src/login/i18n.ts
+++ b/src/login/i18n.ts
@@ -67,7 +67,7 @@ const { useI18n, ofTypeI18n } = i18nBuilder
       invalidUsernameOrEmailMessage:
         " We do not have an account for that email on record. Please try another email or sign up for free.",
       invalidPasswordMessage:
-        "The password you have entered is incorrect. Please try again or select Forgot Password below.",
+        "The password you have entered is incorrect. Please try again or select Reset Password below.",
       expiredCodeMessage: "Sign in timeout. Please sign in again.",
       expiredActionMessage: "Action expired. Please continue with sign in now.",
       federatedIdentityExistsMessage:

--- a/src/login/pages/LoginPassword.stories.tsx
+++ b/src/login/pages/LoginPassword.stories.tsx
@@ -61,6 +61,26 @@ export const WithPasswordError: Story = {
   )
 }
 
+export const WithPasswordGlobalError: Story = {
+  render: () => (
+    <KcPageStory
+      kcContext={{
+        realm: {
+          resetPasswordAllowed: true
+        },
+        url: {
+          loginAction: "/mock-login",
+          loginResetCredentialsUrl: "/mock-reset-password"
+        },
+        message: {
+          summary: "The password you have entered is incorrect. Please try again or select Reset Password below.",
+          type: "error"
+        }
+      }}
+    />
+  )
+}
+
 /**
  * WithoutResetPasswordOption:
  * - Purpose: Tests the behavior when the reset password option is disabled.

--- a/src/login/pages/LoginPassword.tsx
+++ b/src/login/pages/LoginPassword.tsx
@@ -20,7 +20,6 @@ export default function LoginPassword(props: PageProps<Extract<KcContext, { page
       doUseDefaultCss={doUseDefaultCss}
       classes={classes}
       headerNode={loginAttempt?.userFullname ? msg("loginGreeting", loginAttempt.userFullname) : ""}
-      displayMessage={!messagesPerField.existsError("password")}
     >
       <div id="kc-form">
         <div id="kc-form-wrapper">


### PR DESCRIPTION
### What are the relevant tickets?

- Closes https://github.com/mitodl/hq/issues/8550

### Description (What does it do?)
<!--- Describe your changes in detail -->

Displays the Keycloak global error on the password form.

### Screenshots (if appropriate):
<!--- optional - delete if empty --->


<img width="781" height="699" alt="image" src="https://github.com/user-attachments/assets/8394c8b6-0210-4a24-a6eb-ad544c9adf2f" />


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

- Run `yarn start`.
- Enter email followed by an incorrect password.
- Check that you see the incorrect password message.

- Run `yarn storybook`.
- Story is provided at http://localhost:6006/?path=/story/login-login-password-ftl--with-password-global-error

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->

Locally we get a field level error, while on RC and Prod we get a global error for the form. The global errors were not being show if we had a field level error as the designs show the error against the field and we do not want to display both.

We could display the global error against the field, though ideally don't want to be applying logic specific to this form instead render errors that Keycloak considers form level consistently.

<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
