### PR TITLE
Fix the registration page "Log In" link

### DIFF
--- a/src/login/pages/Register.tsx
+++ b/src/login/pages/Register.tsx
@@ -97,7 +97,7 @@ export default function Register(props: RegisterProps) {
             <div>
               <Info>
                 {msg("alreadyHaveAnAccountRegister")}
-                <Link href={url.loginUrl}>{msg("backToLogin")}</Link>.
+                <Link href={url.loginRestartFlowUrl}>{msg("backToLogin")}</Link>.
               </Info>
             </div>
           </div>


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->

- Fixes https://github.com/mitodl/hq/issues/8596

### Description (What does it do?)
<!--- Describe your changes in detail -->

Changes the link to use the `url.loginRestartFlowUrl` from the Keycloak context, instead of `url.loginUrl`.

`url.loginUrl` works locally, but on RC+Prod we are redirected back to the registration page, reason unclear.

Testing `url.loginRestartFlowUrl` directly on RC confirms that it correctly returns users to the initial login page and its name better reflects the intended behavior.



### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

- Run `yarn start`.
- Enter an email not registered to reach the registration screen. 
  - Depending on your local setup, you may need to log `kcContext.url.registrationUrl` for the registration screen address.
- Click the Already have an account? "Log In." link.
- Confirm you are returned to the initial login screen.
- Can also check in advance on RC by logging `kcContext.url.loginRestartFlowUrl` on the registration page and pasting the path into the address bar (same tab).

