### PR TITLE
Login page natural tab flow

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ol-keycloakify",
-  "version": "0.0.24",
+  "version": "0.0.25",
   "description": "Keycloakify theme for Open Learning",
   "repository": {
     "type": "git",

--- a/src/login/pages/Login.tsx
+++ b/src/login/pages/Login.tsx
@@ -91,15 +91,13 @@ export default function Login(props: PageProps<Extract<KcContext, { pageId: "log
                 <div>
                   {realm.resetPasswordAllowed && (
                     <span>
-                      <Link tabIndex={0} href={url.loginResetCredentialsUrl}>
-                        {msg("doForgotPassword")}
-                      </Link>
+                      <Link href={url.loginResetCredentialsUrl}>{msg("doForgotPassword")}</Link>
                     </span>
                   )}
                 </div>
                 <div id="kc-form-buttons">
                   <input type="hidden" id="id-hidden-input" name="credentialId" value={auth.selectedCredential} />
-                  <Button tabIndex={0} disabled={isLoginButtonDisabled} name="login" id="kc-login" type="submit" variant="primary" size="large">
+                  <Button disabled={isLoginButtonDisabled} name="login" id="kc-login" type="submit" variant="primary" size="large">
                     {msgStr("doLogIn")}
                   </Button>
                 </div>

--- a/src/login/pages/LoginPassword.tsx
+++ b/src/login/pages/LoginPassword.tsx
@@ -48,13 +48,11 @@ export default function LoginPassword(props: PageProps<Extract<KcContext, { page
             />
             {realm.resetPasswordAllowed && (
               <span>
-                <Link tabIndex={0} href={url.loginResetCredentialsUrl}>
-                  {msg("doForgotPassword")}
-                </Link>
+                <Link href={url.loginResetCredentialsUrl}>{msg("doForgotPassword")}</Link>
               </span>
             )}
             <div id="kc-form-buttons">
-              <Button tabIndex={0} name="login" id="kc-login" type="submit" disabled={isLoginButtonDisabled} size="large">
+              <Button name="login" id="kc-login" type="submit" disabled={isLoginButtonDisabled} size="large">
                 Next
               </Button>
             </div>

--- a/src/login/pages/LoginUsername.tsx
+++ b/src/login/pages/LoginUsername.tsx
@@ -79,7 +79,7 @@ export default function LoginUsername(props: PageProps<Extract<KcContext, { page
                 />
               )}
               <div id="kc-form-buttons">
-                <Button tabIndex={4} disabled={isLoginButtonDisabled} name="login" id="kc-login" type="submit" size="large">
+                <Button disabled={isLoginButtonDisabled} name="login" id="kc-login" type="submit" size="large">
                   Next
                 </Button>
               </div>


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->

Closes https://github.com/mitodl/hq/issues/8558

### Description (What does it do?)
<!--- Describe your changes in detail -->

- Removes the positive `tabIndex={4}` from the Next button on the login page, allowing the natural DOM order to determine tab navigation.
- Removes redundant `tabIndex={0}` elsewhere (no functional change).

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

- Run `yarn start` to fire up Keycloak.
- Navigate to the mock client at https://my-theme.keycloakify.dev/ to redirect to login.
- The email input should be focused.
- Press tab. The Next button should be autofocused.
- Click anywhere on the page and continue hitting tab. The focus should cycle through the focusable elements in the order they naturally appear:
  1.  MIT link
  2. Email input
  3. Next button
  4. Terms of Service link
