### PR TITLE
Trim spaces on email inputs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ol-keycloakify",
-  "version": "0.0.25",
+  "version": "0.0.26",
   "description": "Keycloakify theme for Open Learning",
   "repository": {
     "type": "git",

--- a/src/login/UserProfileFormFields.tsx
+++ b/src/login/UserProfileFormFields.tsx
@@ -280,7 +280,11 @@ function InputTag(props: InputFieldByTypeProps & { fieldIndex: number | undefine
 
           assert(typeof valueOrValues === "string")
 
-          return initialValue || valueOrValues
+          if (attribute.name === "email") {
+            return initialValue || valueOrValues?.trim()
+          }
+
+          return valueOrValues
         })()}
         placeholder={
           attribute.annotations.inputTypePlaceholder === undefined ? undefined : advancedMsgStr(attribute.annotations.inputTypePlaceholder)
@@ -307,6 +311,10 @@ function InputTag(props: InputFieldByTypeProps & { fieldIndex: number | undefine
 
                   return value
                 })
+              }
+
+              if (attribute.name === "email") {
+                return event.target.value?.trim() ?? ""
               }
 
               return event.target.value

--- a/src/login/pages/LoginUsername.tsx
+++ b/src/login/pages/LoginUsername.tsx
@@ -74,8 +74,9 @@ export default function LoginUsername(props: PageProps<Extract<KcContext, { page
                   errorText={messagesPerField.getFirstError("username")}
                   error={messagesPerField.existsError("username")}
                   onChange={e => {
-                    setUsername(e.target.value)
+                    setUsername(e.target.value.trim())
                   }}
+                  value={username}
                 />
               )}
               <div id="kc-form-buttons">


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->

Closes: https://github.com/mitodl/hq/issues/8804

### Description (What does it do?)
<!--- Describe your changes in detail -->

Trims leading and trailing spaces on email input.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

- Run `yarn start` and load https://my-theme.keycloakify.dev/
- Attempt to enter an email with leading or trailing spaces and confirm that they cannot be entered.
- Check that the same is true in the registration form (log `kcContext.url.registrationUrl` for the path).
- Check that you can create an account successfully and log in with that account.
