### PR TITLE
Fix password form visibility for org users

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ol-keycloakify",
-  "version": "0.0.30",
+  "version": "0.0.31",
   "description": "Keycloakify theme for Open Learning",
   "repository": {
     "type": "git",

--- a/src/login/KcContext.ts
+++ b/src/login/KcContext.ts
@@ -11,7 +11,9 @@ export type KcContextExtension = {
   loginAttempt: {
     userFullname?: string
     needsPassword: boolean
-    hasSocialProviderAuth: boolean
+    // Deprecated: No longer used in template logic (removed from Login.tsx to fix bug where
+    // users with both SSO and password auth get stuck)
+    hasSocialProviderAuth?: boolean
   }
 
   olSettings: {

--- a/src/login/pages/Login.stories.tsx
+++ b/src/login/pages/Login.stories.tsx
@@ -38,7 +38,6 @@ export const WithNeedsPassword: Story = {
         realm: { resetPasswordAllowed: true },
         loginAttempt: {
           userFullname: "First Last",
-          hasSocialProviderAuth: false,
           needsPassword: true
         }
       }}
@@ -53,7 +52,6 @@ export const WithNeedsPasswordNoReset: Story = {
         realm: { resetPasswordAllowed: false },
         loginAttempt: {
           userFullname: "First Last",
-          hasSocialProviderAuth: false,
           needsPassword: true
         }
       }}

--- a/src/login/pages/Login.tsx
+++ b/src/login/pages/Login.tsx
@@ -43,7 +43,6 @@ export default function Login(props: PageProps<Extract<KcContext, { pageId: "log
       <div id="kc-form">
         <div id="kc-form-wrapper">
           {realm.password &&
-            !loginAttempt?.hasSocialProviderAuth &&
             (!loginAttempt?.needsPassword ? (
               <Form
                 id="kc-form-login"


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->

- Fixes https://github.com/mitodl/hq/issues/9692

- Supersedes https://github.com/mitodl/ol-keycloakify/pull/102

### Description (What does it do?)
<!--- Describe your changes in detail -->


When org-linked users change their password via the account settings page, they can end up in an unrecoverable state:

1. User changes password -> redirected to `login.ftl` (the password entry screen).
2. `kcContext.usernameHidden` is `true` (email input hidden - user is already identified).
3. `kcContext.realm.password` is `true` (password authentication is enabled).
4. `loginAttempt?.hasSocialProviderAuth` is `true` (user is org-linked).
5. The `hasSocialProviderAuth` check on `login.ftl` prevents the password form from showing.
6. User cannot proceed with authentication - blank page with no way to authenticate.

**Original Purpose**: The `hasSocialProviderAuth` check was added to hide the password field on the login screen so Touchstone users wouldn't be tempted to use it.

**Current State**: This check is no longer needed and is causing bugs for users who have both SSO and local password options.

This change removes the `!loginAttempt?.hasSocialProviderAuth` check that hid the password form for org-linked users.


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

The thread on https://github.com/mitodl/hq/issues/9692 speculates that an org-user lands on login-username.ftl after changing their password. This fix is applied to login.ftl - we need to check the `kcContext.pageId` to ensure that no bug exists in login-username.ftl. That template displays the same screen with no form or button if `realm.password` is false.

This can be tested locally if we have a matching RC/Prod Keycloak config, but it is more reliably tested on RC:

- In an incognito window.
- Singed in with an @mit.edu or org-linked login.
- Open https://mitxonline.mit.edu/account-settings/.
- Hit Change Password.
- Change your password.
- Verify that `window.kcContext.pageId` is `"login.ftl"`.
- Verify that you see the password input and Next button.
- Verify that you do **not** see the email input.
- Enter your new password and verify that you are logged in.
- Log out and back in.
- You should be redirected to Touchstone.


### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
