### PR TITLE
email template updates to better match production 

### DIFF
--- a/src/emails/templates/email-verification.tsx
+++ b/src/emails/templates/email-verification.tsx
@@ -38,12 +38,6 @@ export const Template = ({ locale }: Omit<GetTemplateProps, "plainText">) => (
       <br />
       <strong>{exp("realmName")} Team</strong>
     </Text>
-    <Text style={fallbackUrl}>
-      If you&apos;re unable to click the button above, copy and paste the following URL
-      into your browser:
-      <br />
-      {exp("link")}
-    </Text>
   </EmailLayout>
 )
 

--- a/src/emails/templates/org-invite.tsx
+++ b/src/emails/templates/org-invite.tsx
@@ -58,12 +58,6 @@ export const Template = ({ locale, themeName }: Omit<GetTemplateProps, "plainTex
           ? "If you have questions about data usage policies or technical requirements, please contact the platform administration team."
           : `If you did not expect this invitation or have any questions, please contact the ${exp("realmName")} support team.`}
       </Text>
-      <Text style={fallbackUrl}>
-        If you&apos;re unable to click the button above, copy and paste the following URL
-        into your browser:
-        <br />
-        {exp("link")}
-      </Text>
     </EmailLayout>
   )
 }

--- a/src/emails/templates/org-invite.tsx
+++ b/src/emails/templates/org-invite.tsx
@@ -55,7 +55,7 @@ export const Template = ({ locale, themeName }: Omit<GetTemplateProps, "plainTex
       </Text>
       <Text style={paragraph}>
         {isDataPlatform
-          ? "If you have questions about data usage policies or technical requirements, please contact the platform administration team."
+          ? "If you have questions about data usage policies or technical requirements, please contact odl-data@mit.edu."
           : `If you did not expect this invitation or have any questions, please contact the ${exp("realmName")} support team.`}
       </Text>
     </EmailLayout>

--- a/src/emails/templates/org-invite.tsx
+++ b/src/emails/templates/org-invite.tsx
@@ -13,6 +13,8 @@ export const templateName = "Org Invite"
 
 const { exp } = createVariablesHelper("org-invite.ftl")
 
+const DATA_PLATFORM_CONTACT_EMAIL = "odl-data@mit.edu"
+
 export const Template = ({ locale, themeName }: Omit<GetTemplateProps, "plainText">) => {
   const isDataPlatform = themeName === "ol-data-platform"
 
@@ -55,7 +57,7 @@ export const Template = ({ locale, themeName }: Omit<GetTemplateProps, "plainTex
       </Text>
       <Text style={paragraph}>
         {isDataPlatform
-          ? "If you have questions about data usage policies or technical requirements, please contact odl-data@mit.edu."
+          ? `If you have questions about data usage policies or technical requirements, please contact ${DATA_PLATFORM_CONTACT_EMAIL}.`
           : `If you did not expect this invitation or have any questions, please contact the ${exp("realmName")} support team.`}
       </Text>
     </EmailLayout>

--- a/src/emails/templates/password-reset.tsx
+++ b/src/emails/templates/password-reset.tsx
@@ -44,5 +44,5 @@ export const getTemplate: GetTemplate = async props => {
 }
 
 export const getSubject: GetSubject = async () => {
-  return "Reset password"
+  return "Your Password Reset Link"
 }

--- a/src/emails/templates/password-reset.tsx
+++ b/src/emails/templates/password-reset.tsx
@@ -36,12 +36,6 @@ export const Template = ({ locale }: Omit<GetTemplateProps, "plainText">) => (
     <Text style={paragraph}>
       This link will expire within {exp("linkExpirationFormatter(linkExpiration)")}.
     </Text>
-    <Text style={fallbackUrl}>
-      If you&apos;re unable to click the button above, copy and paste the following URL
-      into your browser:
-      <br />
-      {exp("link")}
-    </Text>
   </EmailLayout>
 )
 


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->

N/A 

### Description (What does it do?)
<!--- Describe your changes in detail -->

Aligns the Keycloakify email templates with the ones used in production by
- removing the raw link, which doesn't render correctly in most email clients anyway
- adds an email address for the data platform onboarding email
- leaves the expiration message, since this seems somewhat useful -- even though I would like to increase the timeout

### Screenshots (if appropriate):
<!--- optional - delete if empty --->

This is the target, from production:

<img width="632" height="451" alt="image" src="https://github.com/user-attachments/assets/da69ece7-6003-4a54-8ed7-59a3874752fb" />

<img width="646" height="505" alt="image" src="https://github.com/user-attachments/assets/05eb15d9-388d-445f-be84-0d32bfef5e31" />

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

I wish I knew

