### PR TITLE
only match org domains explicitly

### DIFF
--- a/src/login/KcPageStory.tsx
+++ b/src/login/KcPageStory.tsx
@@ -23,11 +23,30 @@ const kcContextExtension: KcContextExtension = {
 
 const kcContextExtensionPerPage: KcContextExtensionPerPage = {}
 
+const emailValidatorOverride = {
+  profile: {
+    attributesByName: {
+      email: {
+        validators: {
+          pattern: undefined,
+          email: { "ignore.empty.value": true },
+          length: { max: 255, "ignore.empty.value": true }
+        }
+      }
+    }
+  }
+}
+
 export const { getKcContextMock } = createGetKcContextMock({
   kcContextExtension,
   kcContextExtensionPerPage,
   overrides: {},
-  overridesPerPage: {}
+  overridesPerPage: {
+    // The Keycloakify default mock uses a gmail.com pattern validator which doesn't exist
+    // in production. Override with the actual production validators from olapps.py:185-194.
+    "register.ftl": emailValidatorOverride,
+    "update-email.ftl": emailValidatorOverride
+  }
 })
 
 export function createKcPageStory<PageId extends KcContext["pageId"]>(params: {

--- a/src/login/UserProfileFormFields.tsx
+++ b/src/login/UserProfileFormFields.tsx
@@ -14,13 +14,14 @@ import type { KcContext } from "./KcContext"
 import type { I18n } from "./i18n"
 import { Label, ValidationMessage, RevealPasswordButton, HelperText, Suggestion } from "./components/Elements"
 import { StyledTextField } from "./components/Elements"
-import { ORG_EMAIL_DOMAINS } from "./constants"
+import { ORG_EMAIL_DOMAINS, NON_TOUCHSTONE_MIT_DOMAINS } from "./constants"
 
 const isOrgEmail = (email: string): boolean => {
   if (!email || !email.trim()) return false
   const emailParts = email.trim().split("@")
   if (emailParts.length !== 2) return false
   const domain = emailParts[1].toLowerCase()
+  if (NON_TOUCHSTONE_MIT_DOMAINS.some((d) => domain === d.toLowerCase())) return false
   return ORG_EMAIL_DOMAINS.some(
     (orgEmailDomain: string) => domain === orgEmailDomain.toLowerCase() || domain.endsWith(`.${orgEmailDomain.toLowerCase()}`)
   )

--- a/src/login/UserProfileFormFields.tsx
+++ b/src/login/UserProfileFormFields.tsx
@@ -15,14 +15,7 @@ import type { I18n } from "./i18n"
 import { Label, ValidationMessage, RevealPasswordButton, HelperText, Suggestion } from "./components/Elements"
 import { StyledTextField } from "./components/Elements"
 import { ORG_EMAIL_DOMAINS } from "./constants"
-
-const isOrgEmail = (email: string): boolean => {
-  if (!email || !email.trim()) return false
-  const emailParts = email.trim().split("@")
-  if (emailParts.length !== 2) return false
-  const domain = emailParts[1].toLowerCase()
-  return ORG_EMAIL_DOMAINS.some((orgEmailDomain: string) => domain === orgEmailDomain.toLowerCase())
-}
+import { isOrgEmail } from "./email"
 
 export default function UserProfileFormFields(
   props: Omit<UserProfileFormFieldsProps<KcContext, I18n>, "kcClsx"> & {

--- a/src/login/UserProfileFormFields.tsx
+++ b/src/login/UserProfileFormFields.tsx
@@ -14,17 +14,14 @@ import type { KcContext } from "./KcContext"
 import type { I18n } from "./i18n"
 import { Label, ValidationMessage, RevealPasswordButton, HelperText, Suggestion } from "./components/Elements"
 import { StyledTextField } from "./components/Elements"
-import { ORG_EMAIL_DOMAINS, NON_TOUCHSTONE_MIT_DOMAINS } from "./constants"
+import { ORG_EMAIL_DOMAINS } from "./constants"
 
 const isOrgEmail = (email: string): boolean => {
   if (!email || !email.trim()) return false
   const emailParts = email.trim().split("@")
   if (emailParts.length !== 2) return false
   const domain = emailParts[1].toLowerCase()
-  if (NON_TOUCHSTONE_MIT_DOMAINS.some((d) => domain === d.toLowerCase())) return false
-  return ORG_EMAIL_DOMAINS.some(
-    (orgEmailDomain: string) => domain === orgEmailDomain.toLowerCase() || domain.endsWith(`.${orgEmailDomain.toLowerCase()}`)
-  )
+  return ORG_EMAIL_DOMAINS.some((orgEmailDomain: string) => domain === orgEmailDomain.toLowerCase())
 }
 
 export default function UserProfileFormFields(

--- a/src/login/constants.ts
+++ b/src/login/constants.ts
@@ -4,6 +4,7 @@ import emailSpellChecker from "@zootools/email-spell-checker"
  * On the login screen, emails that closely match are shown a suggestion for typo corrections.
  * On the registration screen, users attempting to register with MIT email addresses are shown a message to return to login.
  */
+
 export const ORG_EMAIL_DOMAINS = [
   // https://github.com/mitodl/ol-infrastructure/blob/a0d3000743e198c6a8c91d5a8c87d64de553e15e/src/ol_infrastructure/substructure/keycloak/olapps.py#L672-L688
   "mit.edu",
@@ -22,6 +23,14 @@ export const ORG_EMAIL_DOMAINS = [
   "smart.mit.edu",
   "solve.mit.edu",
   "wi.mit.edu"
+]
+
+/* MIT-affiliated domains that are NOT supported by Touchstone and should be excluded from
+ * the Touchstone redirect/registration block. Users with these addresses need to register
+ * directly via Keycloak.
+ */
+export const NON_TOUCHSTONE_MIT_DOMAINS = [
+  "alum.mit.edu"
 ]
 
 export const EMAIL_SUGGESTION_DOMAINS = [

--- a/src/login/constants.ts
+++ b/src/login/constants.ts
@@ -25,13 +25,6 @@ export const ORG_EMAIL_DOMAINS = [
   "wi.mit.edu"
 ]
 
-/* MIT-affiliated domains that are NOT supported by Touchstone and should be excluded from
- * the Touchstone redirect/registration block. Users with these addresses need to register
- * directly via Keycloak.
- */
-export const NON_TOUCHSTONE_MIT_DOMAINS = [
-  "alum.mit.edu"
-]
 
 export const EMAIL_SUGGESTION_DOMAINS = [
   ...ORG_EMAIL_DOMAINS,

--- a/src/login/constants.ts
+++ b/src/login/constants.ts
@@ -4,7 +4,6 @@ import emailSpellChecker from "@zootools/email-spell-checker"
  * On the login screen, emails that closely match are shown a suggestion for typo corrections.
  * On the registration screen, users attempting to register with MIT email addresses are shown a message to return to login.
  */
-
 export const ORG_EMAIL_DOMAINS = [
   // https://github.com/mitodl/ol-infrastructure/blob/a0d3000743e198c6a8c91d5a8c87d64de553e15e/src/ol_infrastructure/substructure/keycloak/olapps.py#L672-L688
   "mit.edu",
@@ -24,7 +23,6 @@ export const ORG_EMAIL_DOMAINS = [
   "solve.mit.edu",
   "wi.mit.edu"
 ]
-
 
 export const EMAIL_SUGGESTION_DOMAINS = [
   ...ORG_EMAIL_DOMAINS,

--- a/src/login/email.test.ts
+++ b/src/login/email.test.ts
@@ -32,5 +32,6 @@ describe("isOrgEmail", () => {
     expect(isOrgEmail("notanemail")).toBe(false)
     expect(isOrgEmail("   ")).toBe(false)
     expect(isOrgEmail("@mit.edu")).toBe(false)
+    expect(isOrgEmail("user@")).toBe(false)
   })
 })

--- a/src/login/email.test.ts
+++ b/src/login/email.test.ts
@@ -31,5 +31,6 @@ describe("isOrgEmail", () => {
     expect(isOrgEmail("")).toBe(false)
     expect(isOrgEmail("notanemail")).toBe(false)
     expect(isOrgEmail("   ")).toBe(false)
+    expect(isOrgEmail("@mit.edu")).toBe(false)
   })
 })

--- a/src/login/email.test.ts
+++ b/src/login/email.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest"
+import { isOrgEmail } from "./email"
+
+describe("isOrgEmail", () => {
+  it("returns true for exact Touchstone domains", () => {
+    expect(isOrgEmail("user@mit.edu")).toBe(true)
+    expect(isOrgEmail("user@csail.mit.edu")).toBe(true)
+    expect(isOrgEmail("user@sloan.mit.edu")).toBe(true)
+    expect(isOrgEmail("user@media.mit.edu")).toBe(true)
+  })
+
+  it("is case-insensitive", () => {
+    expect(isOrgEmail("user@MIT.EDU")).toBe(true)
+    expect(isOrgEmail("user@CSAIL.MIT.EDU")).toBe(true)
+  })
+
+  it("returns false for non-MIT domains", () => {
+    expect(isOrgEmail("user@gmail.com")).toBe(false)
+    expect(isOrgEmail("user@harvard.edu")).toBe(false)
+  })
+
+  it("returns false for alum.mit.edu (not a Touchstone domain)", () => {
+    expect(isOrgEmail("user@alum.mit.edu")).toBe(false)
+  })
+
+  it("returns false for unlisted mit.edu subdomains", () => {
+    expect(isOrgEmail("user@some-lab.mit.edu")).toBe(false)
+  })
+
+  it("returns false for empty or invalid input", () => {
+    expect(isOrgEmail("")).toBe(false)
+    expect(isOrgEmail("notanemail")).toBe(false)
+    expect(isOrgEmail("   ")).toBe(false)
+  })
+})

--- a/src/login/email.ts
+++ b/src/login/email.ts
@@ -1,11 +1,12 @@
 import { ORG_EMAIL_DOMAINS } from "./constants"
 
 export const isOrgEmail = (email: string): boolean => {
-  if (!email || !email.trim()) return false
-  const emailParts = email.trim().split("@")
-  if (emailParts.length !== 2) return false
-  const domain = emailParts[1].toLowerCase()
+  const trimmed = email?.trim()
+  if (!trimmed) return false
+  const lastAtIndex = trimmed.lastIndexOf("@")
+  if (lastAtIndex <= 0 || lastAtIndex === trimmed.length - 1) return false
+  const domain = trimmed.slice(lastAtIndex + 1).toLowerCase()
   return ORG_EMAIL_DOMAINS.some(
-    (orgEmailDomain: string) => domain === orgEmailDomain.toLowerCase()
+    (orgEmailDomain: string) => domain === orgEmailDomain.toLowerCase(),
   )
 }

--- a/src/login/email.ts
+++ b/src/login/email.ts
@@ -1,0 +1,9 @@
+import { ORG_EMAIL_DOMAINS } from "./constants"
+
+export const isOrgEmail = (email: string): boolean => {
+  if (!email || !email.trim()) return false
+  const emailParts = email.trim().split("@")
+  if (emailParts.length !== 2) return false
+  const domain = emailParts[1].toLowerCase()
+  return ORG_EMAIL_DOMAINS.some((orgEmailDomain: string) => domain === orgEmailDomain.toLowerCase())
+}

--- a/src/login/email.ts
+++ b/src/login/email.ts
@@ -7,6 +7,6 @@ export const isOrgEmail = (email: string): boolean => {
   if (lastAtIndex <= 0 || lastAtIndex === trimmed.length - 1) return false
   const domain = trimmed.slice(lastAtIndex + 1).toLowerCase()
   return ORG_EMAIL_DOMAINS.some(
-    (orgEmailDomain: string) => domain === orgEmailDomain.toLowerCase(),
+    (orgEmailDomain: string) => domain === orgEmailDomain.toLowerCase()
   )
 }

--- a/src/login/email.ts
+++ b/src/login/email.ts
@@ -5,5 +5,7 @@ export const isOrgEmail = (email: string): boolean => {
   const emailParts = email.trim().split("@")
   if (emailParts.length !== 2) return false
   const domain = emailParts[1].toLowerCase()
-  return ORG_EMAIL_DOMAINS.some((orgEmailDomain: string) => domain === orgEmailDomain.toLowerCase())
+  return ORG_EMAIL_DOMAINS.some(
+    (orgEmailDomain: string) => domain === orgEmailDomain.toLowerCase()
+  )
 }

--- a/src/login/pages/Register.tsx
+++ b/src/login/pages/Register.tsx
@@ -14,9 +14,7 @@ const isOrgEmail = (email: string): boolean => {
   const emailParts = email.trim().split("@")
   if (emailParts.length !== 2) return false
   const domain = emailParts[1].toLowerCase()
-  return ORG_EMAIL_DOMAINS.some(
-    (orgEmailDomain: string) => domain === orgEmailDomain.toLowerCase() || domain.endsWith(`.${orgEmailDomain.toLowerCase()}`)
-  )
+  return ORG_EMAIL_DOMAINS.some((orgEmailDomain: string) => domain === orgEmailDomain.toLowerCase())
 }
 
 type RegisterProps = PageProps<Extract<KcContext, { pageId: "register.ftl" }>, I18n> & {

--- a/src/login/pages/Register.tsx
+++ b/src/login/pages/Register.tsx
@@ -7,15 +7,7 @@ import type { PageProps } from "keycloakify/login/pages/PageProps"
 import type { KcContext } from "../KcContext"
 import type { I18n } from "../i18n"
 import { Form, ValidationMessage, Button, Link, Info, Subtitle } from "../components/Elements"
-import { ORG_EMAIL_DOMAINS } from "../constants"
-
-const isOrgEmail = (email: string): boolean => {
-  if (!email || !email.trim()) return false
-  const emailParts = email.trim().split("@")
-  if (emailParts.length !== 2) return false
-  const domain = emailParts[1].toLowerCase()
-  return ORG_EMAIL_DOMAINS.some((orgEmailDomain: string) => domain === orgEmailDomain.toLowerCase())
-}
+import { isOrgEmail } from "../email"
 
 type RegisterProps = PageProps<Extract<KcContext, { pageId: "register.ftl" }>, I18n> & {
   UserProfileFormFields: LazyOrNot<


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/11538

### Description (What does it do?)
This PR changes the `isOrgEmail` function to match on domains in `ORG_EMAIL_DOMAINS` explicitly, rather than just blindly accepting subdomains of any of them. The functionality was also deduplicated between the user profile page and the registration page. Some tests were added to avoid regression. The Storybook configuration was also updated. By default, Storybook adds a validator to email fields that is hard coded to only accept gmail addresses. I set these rules to be the same as our config in `ol-infrastructure`, which boils down to:

- It's an email address
- It's less than 255 characters

This makes it so our stories in Storybook actually behave as described.

### How can this be tested?
- Spin up storybook (`yarn install && yarn storybook`)
- In the default registration story, try and type an email with `@alum.mit.edu` and you should not get a validation error
- Try an `@mit.edu` email and you should see the validation error telling you to go back and use your identity provider
- Try the same thing on the email update story
- Run `yarn test` and the tests should pass
