### PR TITLE
bump version to 0.1.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ol-keycloakify",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Keycloakify theme for Open Learning",
   "repository": {
     "type": "git",


### PR DESCRIPTION
### What are the relevant tickets?
Follow up to https://github.com/mitodl/ol-keycloakify/pull/142

### Description (What does it do?)
Forgot to bump the version in the above PR, this does that.
