### PR TITLE
Add Remember Me login option

### DIFF
--- a/src/login/components/Elements.tsx
+++ b/src/login/components/Elements.tsx
@@ -5,6 +5,7 @@ import {
   Alert as SmootAlert,
   Button as SmootButton,
   ButtonLink as SmootButtonLink,
+  Checkbox as SmootCheckbox,
   Input as SmootInput,
   TextField
 } from "@mitodl/smoot-design"
@@ -29,6 +30,10 @@ export const Label = styled.label(({ theme }) => ({
 }))
 
 export const Input = styled(SmootInput)({
+  width: "100%"
+})
+
+export const Checkbox = styled(SmootCheckbox)({
   width: "100%"
 })
 

--- a/src/login/components/Elements.tsx
+++ b/src/login/components/Elements.tsx
@@ -34,7 +34,7 @@ export const Input = styled(SmootInput)({
 })
 
 export const Checkbox = styled(SmootCheckbox)({
-  width: "100%"
+  width: "fit-content"
 })
 
 export const Button = styled(SmootButton)({

--- a/src/login/pages/LoginUsername.tsx
+++ b/src/login/pages/LoginUsername.tsx
@@ -2,7 +2,7 @@ import emailSpellChecker from "@zootools/email-spell-checker"
 import type { PageProps } from "keycloakify/login/pages/PageProps"
 import { clsx } from "keycloakify/tools/clsx"
 import { useCallback, useEffect, useRef, useState } from "react"
-import { Button, Form, OrBar, SocialProviderButtonLink, StyledTextField, Suggestion, ValidationMessage } from "../components/Elements"
+import { Button, Checkbox, Form, OrBar, SocialProviderButtonLink, StyledTextField, Suggestion, ValidationMessage } from "../components/Elements"
 import mitLogo from "../components/mit-logo.svg"
 import { EMAIL_SPELLCHECKER_CONFIG, EMAIL_SUGGESTION_DOMAINS } from "../constants"
 import type { I18n } from "../i18n"
@@ -212,6 +212,11 @@ export default function LoginUsername(props: PageProps<Extract<KcContext, { page
                   )}
                 </div>
               )}
+
+              <div id="kc-form-options">
+                {realm.rememberMe && !usernameHidden && <Checkbox name="rememberMe" checked={!!login.rememberMe} label={msgStr("rememberMe")} />}
+              </div>
+
               <div id="kc-form-buttons">
                 <Button disabled={isSubmitDisabled} name="login" id="kc-login" type="submit" size="large">
                   Next

--- a/src/login/pages/LoginUsername.tsx
+++ b/src/login/pages/LoginUsername.tsx
@@ -23,6 +23,7 @@ export default function LoginUsername(props: PageProps<Extract<KcContext, { page
 
   const { msg, msgStr } = i18n
 
+  const [rememberMe, setRememberMe] = useState(!!login.rememberMe)
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [emailInvalid, setEmailInvalid] = useState(false)
   const [isFocused, setIsFocused] = useState(false)
@@ -214,7 +215,9 @@ export default function LoginUsername(props: PageProps<Extract<KcContext, { page
               )}
 
               <div id="kc-form-options">
-                {realm.rememberMe && !usernameHidden && <Checkbox name="rememberMe" checked={!!login.rememberMe} label={msgStr("rememberMe")} />}
+                {realm.rememberMe && !usernameHidden && (
+                  <Checkbox name="rememberMe" checked={rememberMe} onChange={e => setRememberMe(e.target.checked)} label={msgStr("rememberMe")} />
+                )}
               </div>
 
               <div id="kc-form-buttons">


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
Part of https://github.com/mitodl/hq/issues/8416

### Description (What does it do?)
<!--- Describe your changes in detail -->
This adds the Remember Me option to the login page. I copied the implementation from keycloakify's sources and then converted it to use our smoot design components.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
Storybook if it works for you?

### Screenshots

<img width="1101" height="1011" alt="Screenshot 2026-07-09 at 11-35-57 MIT Learn" src="https://github.com/user-attachments/assets/cc2bf662-c4d1-43dc-8618-4ff4771af661" />
