### PR TITLE
set posthog cookie on site domain

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,22 +1,23 @@
-import { createRoot } from "react-dom/client";
-import { StrictMode } from "react";
-import posthog from "posthog-js";
-import { PostHogProvider } from "@posthog/react";
-import { KcPage } from "./kc.gen";
+import { PostHogProvider } from "@posthog/react"
+import posthog from "posthog-js"
+import { StrictMode } from "react"
+import { createRoot } from "react-dom/client"
+import { KcPage } from "./kc.gen"
 
 if (window.kcContext?.properties?.POSTHOG_API_KEY) {
   posthog.init(window.kcContext.properties.POSTHOG_API_KEY, {
+    // Scope the posthog cookie to this site's exact domain. Posthog defaults
+    // this to true, which sets the cookie on the root domain (e.g. mit.edu),
+    // sharing it with every other site there.
     cross_subdomain_cookie: false,
-    api_host:
-      window.kcContext.properties.POSTHOG_API_HOST ||
-      "https://us.i.posthog.com",
+    api_host: window.kcContext.properties.POSTHOG_API_HOST || "https://us.i.posthog.com",
     defaults: "2025-11-30",
     autocapture: true,
     capture_pageview: true,
-    capture_pageleave: true,
-  });
+    capture_pageleave: true
+  })
 
-  posthog.startSessionRecording();
+  posthog.startSessionRecording()
 }
 
 // The following block can be uncommented to test a specific page with `yarn dev`
@@ -41,5 +42,5 @@ createRoot(document.getElementById("root")!).render(
         <KcPage kcContext={window.kcContext} />
       </PostHogProvider>
     )}
-  </StrictMode>,
-);
+  </StrictMode>
+)

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,19 +1,22 @@
-import { createRoot } from "react-dom/client"
-import { StrictMode } from "react"
-import posthog from "posthog-js"
-import { PostHogProvider } from "@posthog/react"
-import { KcPage } from "./kc.gen"
+import { createRoot } from "react-dom/client";
+import { StrictMode } from "react";
+import posthog from "posthog-js";
+import { PostHogProvider } from "@posthog/react";
+import { KcPage } from "./kc.gen";
 
 if (window.kcContext?.properties?.POSTHOG_API_KEY) {
   posthog.init(window.kcContext.properties.POSTHOG_API_KEY, {
-    api_host: window.kcContext.properties.POSTHOG_API_HOST || "https://us.i.posthog.com",
+    cross_subdomain_cookie: false,
+    api_host:
+      window.kcContext.properties.POSTHOG_API_HOST ||
+      "https://us.i.posthog.com",
     defaults: "2025-11-30",
     autocapture: true,
     capture_pageview: true,
-    capture_pageleave: true
-  })
+    capture_pageleave: true,
+  });
 
-  posthog.startSessionRecording()
+  posthog.startSessionRecording();
 }
 
 // The following block can be uncommented to test a specific page with `yarn dev`
@@ -38,5 +41,5 @@ createRoot(document.getElementById("root")!).render(
         <KcPage kcContext={window.kcContext} />
       </PostHogProvider>
     )}
-  </StrictMode>
-)
+  </StrictMode>,
+);


### PR DESCRIPTION
### What are the relevant tickets?
For 
- https://github.com/mitodl/hq/issues/11158

### Description (What does it do?)
Set the posthog cookie on site domain (`open.odl.local`, or `learn.mit.edu`, or `rc.learn.mit.edu`) not MIT domain.


### How can this be tested?
1. I suggest just testing https://github.com/mitodl/mit-learn/pull/3680 and seing that this works
2. But if you want to test it here, I guess you could do `yarn start` and point `/etc/hosts` some subdomain like `sso.odl.local` at localhost. Then check the cookie is set on that domain exactly, not `odl.local`

### Additional Context
Setting the cookie on the site domain loses our ability to track **anonymous** (unauthenticated) users across sites within the same project, unless we do special setup like pass distinct_ids via query params in URLs, but that is deemed acceptable.

Companion PR, same change for MIT Learn: https://github.com/mitodl/mit-learn/pull/3680

mitxonline already does this — it has passed `cross_subdomain_cookie: false` since 2023: https://github.com/mitodl/mitxonline/blob/80c2a512f1e3d2a93c06bb4270ba87976cf369ef/frontend/public/src/lib/util.js#L44
